### PR TITLE
Add mission hero and secure admin access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# Brand Directory (MVP)
+# Hemp Brand Directory (MVP)
 
 Minimal Next.js + Supabase starter (no styling).
+This directory unites hemp-based brands around a shared ingredient and purpose, promoting collaboration for the planet and humanity.
+
 
 ## Environment variables (create `.env.local` for local dev and set the same in Netlify)
 NEXT_PUBLIC_SUPABASE_URL=your-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 HCAPTCHA_SECRET=your-hcaptcha-secret  # optional; function included but not wired into the form yet
+ADMIN_USER=some-user
+ADMIN_PASSWORD=strong-password
 
 ## Supabase SQL (run in Supabase > SQL editor)
 -- Enable extensions (safe to run multiple times)

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -25,15 +25,13 @@ export default function Layout({ children }: { children: ReactNode }) {
       <header className="header">
         <div className="container h-14 flex items-center justify-between">
           <Link href="/" className="font-semibold tracking-tight">
-            Brand Directory
+            Hemp Brand Directory
           </Link>
 
           {/* Desktop nav */}
           <nav className="hidden md:flex items-center gap-1">
             <NavLink href="/" label="Directory" />
             <NavLink href="/submit" label="Submit" />
-            <NavLink href="/admin" label="Admin" />
-            <NavLink href="/print-catalog" label="Print" />
           </nav>
 
           {/* Mobile toggle */}
@@ -57,15 +55,21 @@ export default function Layout({ children }: { children: ReactNode }) {
             <nav className="container py-3 flex flex-col gap-2">
               <NavLink href="/" label="Directory" />
               <NavLink href="/submit" label="Submit" />
-              <NavLink href="/admin" label="Admin" />
-              <NavLink href="/print-catalog" label="Print" />
             </nav>
           </div>
         )}
       </header>
 
       <main className="main py-6">{children}</main>
-      <footer className="footer">© {new Date().getFullYear()} Hemp’in</footer>
+      <footer className="footer">
+        <div className="container py-4 flex flex-col sm:flex-row items-center justify-between gap-2">
+          <p>© {new Date().getFullYear()} Hemp’in</p>
+          <nav className="flex items-center gap-3">
+            <NavLink href="/admin" label="Admin" />
+            <NavLink href="/print-catalog" label="Print" />
+          </nav>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname === "/admin") {
+    const auth = req.headers.get("authorization");
+    if (auth) {
+      const basic = auth.split(" ")[1] || "";
+      const [user, pwd] = atob(basic).split(":");
+      if (
+        user === process.env.ADMIN_USER &&
+        pwd === process.env.ADMIN_PASSWORD
+      ) {
+        return NextResponse.next();
+      }
+    }
+
+    return new NextResponse("Authentication required", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": "Basic realm=\"Secure Area\"",
+      },
+    });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin"],
+};
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,14 +43,29 @@ export default function Home() {
 
   return (
     <Layout>
-      {/* HERO */}
+      {/* HERO INTRO */}
+      <section className="mb-6">
+        <div className="card border-black/10 bg-neutral-50 text-center">
+          <div className="max-w-2xl mx-auto">
+            <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight">
+              Hemp Brand Directory
+            </h1>
+            <p className="mt-2 text-neutral-700">
+              Gathering brands built on a single powerful ingredient—hemp—with a common goal of
+              advancing the greater good for our planet and humanity.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* HERO CTA */}
       <section className="mb-6">
         <div className="card border-black/10 bg-neutral-50">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="max-w-2xl">
-              <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight">
-                Join the Hemp & Sustainable Brands Directory
-              </h1>
+              <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight">
+                Join the Hemp Brand Directory
+              </h2>
               <p className="mt-2 text-neutral-700">
                 Be discovered by eco-conscious buyers, partners, and investors. Share your impact—
                 materials, certifications, and positive footprint—in a clean, trusted profile.


### PR DESCRIPTION
## Summary
- Rebrand header to "Hemp Brand Directory" and relocate admin/print links to footer
- Introduce mission hero section inviting collaboration across hemp brands
- Guard `/admin` route with environment-variable based basic auth
- Document project mission and admin env vars in README

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a237246fd483288488f928bc4138a4